### PR TITLE
Add support for 43

### DIFF
--- a/weatherintheclock@JasonLG1979.github.io/extension.js
+++ b/weatherintheclock@JasonLG1979.github.io/extension.js
@@ -19,6 +19,7 @@
  */
 
 const {Clutter, GLib, GObject, St} = imports.gi;
+const [major, minor] = imports.misc.config.PACKAGE_VERSION.split('.').map(s => Number(s));
 
 let panelWeather = null;
 
@@ -27,7 +28,7 @@ function enable() {
         let statusArea = imports.ui.main.panel.statusArea;
         let dateMenu = statusArea.dateMenu;
         let weather = dateMenu._weatherItem._weatherClient;
-        let network = statusArea.aggregateMenu._network;
+        let network = (major < 43) ? statusArea.aggregateMenu._network : statusArea.quickSettings._network;
         let networkIcon = network ? network._primaryIndicator : null;
         panelWeather = new PanelWeather(weather, networkIcon);
         dateMenu.get_first_child().insert_child_above(panelWeather, dateMenu._clockDisplay);

--- a/weatherintheclock@JasonLG1979.github.io/metadata.json
+++ b/weatherintheclock@JasonLG1979.github.io/metadata.json
@@ -3,6 +3,6 @@
 "name": "Weather In The Clock",
 "description": "Display the current Weather in the Clock. GNOME Weather is required for this extension to function.",
 "original-author": "JasonLG1979@github.io",
-"shell-version": ["3.38", "40", "41", "42"],
+"shell-version": ["3.38", "40", "41", "42", "43"],
 "url": "https://github.com/JasonLG1979/gnome-shell-extension-weather-in-the-clock/"
 }


### PR DESCRIPTION
On GNOME Shell 43 the name of the menu to the right side of the panel was changed from `aggregateMenu` to `quickSettings`. This branch renames this property conditionally (based on the version of GNOME Shell) to add support for 43 without having to remove support for previous versions.

I tested this fix on a VM and it works as you can see in the screenshot:
![image](https://user-images.githubusercontent.com/65264536/197431999-bf254c28-cd69-476c-853d-45d8853179f6.png)


All credits go to @Razer0123 who [mentioned](https://github.com/JasonLG1979/gnome-shell-extension-weather-in-the-clock/issues/28#issuecomment-1274886166) this fix in issue #28.

Thanks for developing this awesome extension! :rocket: